### PR TITLE
response_change must return a response

### DIFF
--- a/docs/custom_button.rst
+++ b/docs/custom_button.rst
@@ -38,7 +38,7 @@ Then you can override :code:`response_change` and connect your template to the :
                 obj.save()
                 self.message_user(request, "This villain is now unique")
                 return HttpResponseRedirect(".")
-            super().response_change(request, obj)
+            return super().response_change(request, obj)
 
 This is how your admin looks now.
 


### PR DESCRIPTION
If `response_change` does not return a response, an error similar to this will occur:

```
AttributeError: 'NoneType' object has no attribute 'has_header'
```